### PR TITLE
Add new image size for dynamic images

### DIFF
--- a/otf_regen_thumbs.php
+++ b/otf_regen_thumbs.php
@@ -142,7 +142,14 @@ if ( ! function_exists( 'gambit_otf_regen_thumbs_media_downsize' ) ) {
 	            $size[1],
 	            true
 	        );
-		
+	        
+		// Get attachment meta so we can add new size
+            	$imagedata = wp_get_attachment_metadata( $id );
+
+            	// Save the new size in WP
+            	$imagedata['sizes'][ $size[0].'x'.$size[1] ] = $resized;           
+            	wp_update_attachment_metadata( $id, $imagedata );
+            	
 			// Resize somehow failed
 			if ( ! $resized ) {
 				return false;


### PR DESCRIPTION
Add new image size to attachment meta when size array is specified so dynamically generated image sizes are cleaned up when deleting the attachment.
